### PR TITLE
Add basic travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+sudo: true
+dist: trusty
+language: python
+python:
+  - "3.5"
+jobs:
+  include:
+    # trigger systemtests build only on main branches and not on external prs
+    - if: fork = false AND ( branch = master OR branch = develop )
+      script:
+        - curl -LO --retry 3 https://raw.githubusercontent.com/precice/systemtests/master/trigger_systemtests.py
+          #- travis_wait 60 python trigger_systemtests.py --adapter dealii --wait
+


### PR DESCRIPTION
This is basic travis config. The actual test should be enabled, by commenting out the last line in the config (Should be done when https://github.com/precice/tutorials/pull/31 and https://github.com/precice/systemtests/issues/67 are closed )