### PR TITLE
Properly enable travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,4 @@ jobs:
     - if: fork = false AND ( branch = master OR branch = develop )
       script:
         - curl -LO --retry 3 https://raw.githubusercontent.com/precice/systemtests/master/trigger_systemtests.py
-          #- travis_wait 60 python trigger_systemtests.py --adapter dealii --wait
-
+        - travis_wait 60 python trigger_systemtests.py --adapter dealii --wait


### PR DESCRIPTION
Since https://github.com/precice/systemtests/pull/70 finally got merged, the adapter can now be properly tested. 