### PR TITLE
Add a GitHub building tests

### DIFF
--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -25,7 +25,7 @@ jobs:
                   cd linear_elasticity && \
                   cmake . && \
                   make && \
-                  cd nonlinear_elasticity && \
+                  cd ../nonlinear_elasticity && \
                   cmake . && \
                   make";
          

--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -27,7 +27,7 @@ jobs:
                   make && \
                   cd nonlinear_elasticity && \
                   cmake . && \
-                  make;
+                  make";
          
          echo $command
          

--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -1,0 +1,35 @@
+name: Building
+
+on:
+  push:
+    branches: [ master, develop ]
+  pull_request:
+    branches: [ master, develop ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: setup
+      run: |
+         command="sudo apt-get -y update && \
+                  wget https://github.com/precice/precice/releases/download/v2.1.1/libprecice2_2.1.1_focal.deb && \
+                  sudo apt-get -y install ./libprecice2_2.1.1_focal.deb && \
+                  git clone https://github.com/${{ github.repository }} && \
+                  cd dealii-adapter && \
+                  git fetch origin ${{ github.ref }} && \
+                  git checkout FETCH_HEAD && \
+                  cd linear_elasticity && \
+                  cmake . && \
+                  make && \
+                  cd nonlinear_elasticity && \
+                  cmake . && \
+                  make;
+         
+         echo $command
+         
+         docker pull dealii/dealii:v9.2.0-focal
+         docker run -t dealii/dealii:v9.2.0-focal /bin/sh -c "$command";

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,5 @@ jobs:
     # trigger systemtests build only on main branches and not on external prs
     - if: fork = false AND ( branch = master OR branch = develop )
       script:
-        - curl -LO --retry 3 https://raw.githubusercontent.com/precice/systemtests/master/trigger_systemtests.py
+        - curl -LO --retry 3 https://raw.githubusercontent.com/precice/systemtests/develop/trigger_systemtests.py
         - travis_wait 60 python trigger_systemtests.py --adapter dealii --wait

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
     <img src="https://travis-ci.org/precice/dealii-adapter.svg?branch=master" alt="Build status">
 </a>
 
+![GitHub building](https://github.com/precice/dealii-adapter/workflows/.github/workflows/building.yml/badge.svg)
+
 Coupled structural solvers written with the C++ finite element library deal.II:
 
 - `linear_elasticity` contains a linear-elastic solver based on the [step-8 tutorial program](https://www.dealii.org/9.2.0/doxygen/deal.II/step_8.html) of deal.II

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # dealii-adapter
+![Building](https://github.com/precice/dealii-adapter/workflows/Building/badge.svg)
 <a style="text-decoration: none" href="https://travis-ci.org/precice/dealii-adapter" target="_blank">
     <img src="https://travis-ci.org/precice/dealii-adapter.svg?branch=master" alt="Build status">
 </a>
-
-![GitHub building](https://github.com/precice/dealii-adapter/workflows/.github/workflows/building.yml/badge.svg)
 
 Coupled structural solvers written with the C++ finite element library deal.II:
 


### PR DESCRIPTION
...and trigger travis systemtests on `develop`, as requested by @Eder-K .

The test uses now deal.II v 9.2 and the latest release of precice. As an alternative, we could also test against the recent develop version of deal.II, any suggestions?