### PR TITLE
Initialize MPI optionally

### DIFF
--- a/linear_elasticity/linear_elasticity.cc
+++ b/linear_elasticity/linear_elasticity.cc
@@ -797,6 +797,10 @@ main(int argc, char **argv)
   using namespace Linear_Elasticity;
   using namespace dealii;
 
+#ifdef DEAL_II_WITH_MPI
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+#endif
+
   try
     {
       // Query adapter and deal.II info

--- a/nonlinear_elasticity/nonlinear_elasticity.cc
+++ b/nonlinear_elasticity/nonlinear_elasticity.cc
@@ -1502,6 +1502,10 @@ main(int argc, char **argv)
   using namespace Nonlinear_Elasticity;
   using namespace dealii;
 
+#ifdef DEAL_II_WITH_MPI
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+#endif
+
   try
     {
       deallog.depth_console(0);


### PR DESCRIPTION
I removed the MPI dependency completely in #36. This can lead, however, to an ugly error in case Assertions are used inside of a `TimerScope` since the timer enforces mpi synchronization in case deal.II is compiled with MPI. Therefore, I would initialize MPI in case deal.II was compiled with MPI. 