### PR TITLE
Fix entry declaration in parameter handler

### DIFF
--- a/linear_elasticity/include/parameter_handling.h
+++ b/linear_elasticity/include/parameter_handling.h
@@ -285,7 +285,7 @@ namespace Linear_Elasticity
         mesh_name        = prm.get("Mesh name");
         read_data_name   = prm.get("Read data name");
         write_data_name  = prm.get("Write data name");
-        flap_location    = prm.get_double("Flap x-location");
+        flap_location    = prm.get_double("Flap location");
       }
       prm.leave_subsection();
     }

--- a/nonlinear_elasticity/include/parameter_handling.h
+++ b/nonlinear_elasticity/include/parameter_handling.h
@@ -351,7 +351,7 @@ namespace Nonlinear_Elasticity
         mesh_name        = prm.get("Mesh name");
         read_data_name   = prm.get("Read data name");
         write_data_name  = prm.get("Write data name");
-        flap_location    = prm.get_double("Flap x-location");
+        flap_location    = prm.get_double("Flap location");
       }
       prm.leave_subsection();
     }


### PR DESCRIPTION
The declaration is not consistent with the subsequent `get` entry, which leads to an error.