### PR TITLE
[ci] simplify GH action by re-using local checkout

### DIFF
--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -25,4 +25,5 @@ jobs:
          echo $command
          
          docker pull dealii/dealii:v9.2.0-focal
-         docker run -t -v $PWD:/src dealii/dealii:v9.2.0-focal /bin/sh -c "$command";
+         # need to set uid to allow container user to write to the mount
+         docker run -t --user 0 -v $PWD:/src dealii/dealii:v9.2.0-focal /bin/sh -c "$command";


### PR DESCRIPTION
Making this PR so I can check if the change works.
The action is setup to only run on pushes on master or develop,
is that intentional?
