### PR TITLE
Bump versions of GitHub Actions

### DIFF
--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: setup
       run: |
          command="sudo apt-get -y update && \

--- a/.github/workflows/indent.yml
+++ b/.github/workflows/indent.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: DoozyX/clang-format-lint-action@v0.11
+    - uses: actions/checkout@v6
+    - uses: DoozyX/clang-format-lint-action@v0.20
       with:
         source: '.'
         exclude: ''


### PR DESCRIPTION
Hopefully fixes [this error](https://github.com/precice/dealii-adapter/actions/runs/26371620756/job/77624672953?pr=75):

```
Run DoozyX/clang-format-lint-action@v0.11
/usr/bin/docker run --name a1c4729fab447d4022a14ad733eda12a04_b01a1e --label 2797a1 --workdir /github/workspace --rm -e "INPUT_SOURCE" -e "INPUT_EXCLUDE" -e "INPUT_EXTENSIONS" -e "INPUT_CLANGFORMATVERSION" -e "INPUT_INPLACE" -e "INPUT_STYLE" -e "HOME" -e "GITHUB_JOB" -e "GITHUB_REF" -e "GITHUB_SHA" -e "GITHUB_REPOSITORY" -e "GITHUB_REPOSITORY_OWNER" -e "GITHUB_REPOSITORY_OWNER_ID" -e "GITHUB_RUN_ID" -e "GITHUB_RUN_NUMBER" -e "GITHUB_RETENTION_DAYS" -e "GITHUB_RUN_ATTEMPT" -e "GITHUB_ACTOR_ID" -e "GITHUB_ACTOR" -e "GITHUB_WORKFLOW" -e "GITHUB_HEAD_REF" -e "GITHUB_BASE_REF" -e "GITHUB_EVENT_NAME" -e "GITHUB_SERVER_URL" -e "GITHUB_API_URL" -e "GITHUB_GRAPHQL_URL" -e "GITHUB_REF_NAME" -e "GITHUB_REF_PROTECTED" -e "GITHUB_REF_TYPE" -e "GITHUB_WORKFLOW_REF" -e "GITHUB_WORKFLOW_SHA" -e "GITHUB_REPOSITORY_ID" -e "GITHUB_TRIGGERING_ACTOR" -e "GITHUB_WORKSPACE" -e "GITHUB_ACTION" -e "GITHUB_EVENT_PATH" -e "GITHUB_ACTION_REPOSITORY" -e "GITHUB_ACTION_REF" -e "GITHUB_PATH" -e "GITHUB_ENV" -e "GITHUB_STEP_SUMMARY" -e "GITHUB_STATE" -e "GITHUB_OUTPUT" -e "RUNNER_OS" -e "RUNNER_ARCH" -e "RUNNER_NAME" -e "RUNNER_ENVIRONMENT" -e "RUNNER_TOOL_CACHE" -e "RUNNER_TEMP" -e "RUNNER_WORKSPACE" -e "ACTIONS_RUNTIME_URL" -e "ACTIONS_RUNTIME_TOKEN" -e "ACTIONS_CACHE_URL" -e "ACTIONS_RESULTS_URL" -e "ACTIONS_ORCHESTRATION_ID" -e GITHUB_ACTIONS=true -e CI=true -v "/var/run/docker.sock":"/var/run/docker.sock" -v "/home/runner/work/_temp":"/github/runner_temp" -v "/home/runner/work/_temp/_github_home":"/github/home" -v "/home/runner/work/_temp/_github_workflow":"/github/workflow" -v "/home/runner/work/_temp/_runner_file_commands":"/github/file_commands" -v "/home/runner/work/dealii-adapter/dealii-adapter":"/github/workspace" 2797a1:c4729fab447d4022a14ad733eda12a04  "--clang-format-executable" "/clang-format/clang-format11" "-r" "--style" "file" "--inplace" "true" "--extensions" "h,cc" "--exclude" "" "."
Traceback (most recent call last):
  File "/run-clang-format.py", line 25, in <module>
    from distutils.util import strtobool
ModuleNotFoundError: No module named 'distutils'
```